### PR TITLE
Added SMS email address for Cricket Wireless

### DIFF
--- a/carrier-list.php
+++ b/carrier-list.php
@@ -19,6 +19,7 @@ $wp_sms_carrier_list = array(
 	'Clearnet'                     => '@msg.clearnet.com',
 	'Comcast'                      => '@comcastpcs.textmsg.com',
 	'Corr Wireless Communications' => '@corrwireless.net',
+	'Cricket Wireless'             => '@mms.cricketwireless.net',
 	'Dobson'                       => '@mobile.dobson.net',
 	'Edge Wireless'                => '@sms.edgewireless.com',
 	'Fido'                         => '@fido.ca',


### PR DESCRIPTION
Cricket Wireless is a major MVNO in the US that uses AT&T's network.
(Technically, it's an MMS email address, but it's what they have and it works the same.)
